### PR TITLE
add wandb support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,19 @@
-.DS_Store
+Gemfile.lock
+collect_env.py
+tmp*
+Untitled*.ipynb
+*.bak
+token
+.idea/
+docs/
+conda/
+tmp/
 
+tags
+*~
+~*
+*.swp
+.gitconfig
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -22,8 +36,6 @@ parts/
 sdist/
 var/
 wheels/
-pip-wheel-metadata/
-share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -42,14 +54,12 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-.nox/
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
 *.cover
-*.py,cover
 .hypothesis/
 .pytest_cache/
 
@@ -61,7 +71,6 @@ coverage.xml
 *.log
 local_settings.py
 db.sqlite3
-db.sqlite3-journal
 
 # Flask stuff:
 instance/
@@ -79,26 +88,13 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
-# IPython
-profile_default/
-ipython_config.py
-
 # pyenv
 .python-version
 
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
+.vscode/
 
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
-__pypackages__/
-
-# Celery stuff
+# celery beat schedule file
 celerybeat-schedule
-celerybeat.pid
 
 # SageMath parsed files
 *.sage.py
@@ -124,8 +120,14 @@ venv.bak/
 
 # mypy
 .mypy_cache/
-.dmypy.json
-dmypy.json
 
-# Pyre type checker
-.pyre/
+# Mac stuff
+.DS_Store
+
+# Wandb
+wandb
+MNIST
+data
+*.onnx
+*.pt
+artifacts

--- a/train_benchmark.py
+++ b/train_benchmark.py
@@ -1,8 +1,12 @@
 import argparse
 import time
+import wandb
 import tensorflow as tf
 from tensorflow.keras import mixed_precision
 from model_library import *
+
+PROJECT = "tf-metal-experiments"
+ENTITY = None  #replace with the team id
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--model", type=str, default="resnet50")
@@ -14,44 +18,48 @@ parser.add_argument("--xla", action="store_true")
 parser.add_argument("--fp16", action="store_true")
 args = parser.parse_args()
 
-tf.config.optimizer.set_jit(args.xla)
-if args.fp16:
-    policy = mixed_precision.Policy("mixed_float16")
-    mixed_precision.set_global_policy(policy)
-    
-tf.config.experimental.set_memory_growth(tf.config.list_physical_devices("GPU")[0],
-                                         True)
+print(args)
 
-print("\nConfig:", vars(args))
-print("GPU:", tf.config.list_physical_devices("GPU"))
-print("")
+with wandb.init(project=PROJECT, entity=ENTITY, config=args.__dict__):
+    tf.config.optimizer.set_jit(args.xla)
+    if args.fp16:
+        policy = mixed_precision.Policy("mixed_float16")
+        mixed_precision.set_global_policy(policy)
+        
+    # tf.config.experimental.set_memory_growth(tf.config.list_physical_devices("GPU")[0],
+    #                                         True)
 
-print("\n[1/3] Loading model\n")
+    print("\nConfig:", vars(args))
+    print("GPU:", tf.config.list_physical_devices("GPU"))
+    print("")
 
-if args.type == "cnn":
-    train_items = return_cnn(args.model, batch_size=args.bs, steps=args.steps)
-elif args.type == "transformer":
-    train_items = return_transformer(args.model, batch_size=args.bs, steps=args.steps)
-else:
-    raise ValueError("Model type not supported")
-    
-model = train_items["model"]
-dataset_x, dataset_y = train_items["sample_data"]
+    print("\n[1/3] Loading model\n")
 
-model.summary()
+    if args.type == "cnn":
+        train_items = return_cnn(args.model, batch_size=args.bs, steps=args.steps)
+    elif args.type == "transformer":
+        train_items = return_transformer(args.model, batch_size=args.bs, steps=args.steps)
+    else:
+        raise ValueError("Model type not supported")
+        
+    model = train_items["model"]
+    dataset_x, dataset_y = train_items["sample_data"]
 
-print("\n[2/3] Warm-up run\n")
+    model.summary()
 
-_ = model.fit(x=dataset_x, y=dataset_y, batch_size=args.bs, epochs=1, verbose=1)
+    print("\n[2/3] Warm-up run\n")
 
-print("\n[3/3] Benchmark run\n")
+    _ = model.fit(x=dataset_x, y=dataset_y, batch_size=args.bs, epochs=1, verbose=1)
 
-st = time.time()
-_ = model.fit(x=dataset_x, y=dataset_y, batch_size=args.bs, epochs=args.epochs, verbose=2)
-et = time.time()
+    print("\n[3/3] Benchmark run\n")
+    cbs = [wandb.keras.WandbCallback(save_model=False),]
+    st = time.time()
+    _ = model.fit(x=dataset_x, y=dataset_y, batch_size=args.bs, callbacks=cbs, epochs=args.epochs, verbose=2)
+    et = time.time()
 
-dataset_size = args.bs*args.steps
-fps = round(dataset_size*args.epochs/(et-st), 1)
+    dataset_size = args.bs*args.steps
+    fps = round(dataset_size*args.epochs/(et-st), 1)
 
-print("\nTraining Result:")
-print("Sample/sec:", fps)
+    print("\nTraining Result:")
+    print("Sample/sec:", fps)
+    wandb.log({"fps":fps})

--- a/train_benchmark.py
+++ b/train_benchmark.py
@@ -18,8 +18,7 @@ parser.add_argument("--xla", action="store_true")
 parser.add_argument("--fp16", action="store_true")
 args = parser.parse_args()
 
-def train():
-    """@wandbcode{tf-metal-experiments}""" 
+def train(): 
     with wandb.init(project=PROJECT, entity=ENTITY, config=args.__dict__):
         tf.config.optimizer.set_jit(args.xla)
         if args.fp16:

--- a/train_benchmark.py
+++ b/train_benchmark.py
@@ -18,48 +18,52 @@ parser.add_argument("--xla", action="store_true")
 parser.add_argument("--fp16", action="store_true")
 args = parser.parse_args()
 
+def train():
+    """@wandbcode{tf-metal-experiments}""" 
+    with wandb.init(project=PROJECT, entity=ENTITY, config=args.__dict__):
+        tf.config.optimizer.set_jit(args.xla)
+        if args.fp16:
+            policy = mixed_precision.Policy("mixed_float16")
+            mixed_precision.set_global_policy(policy)
+            
+        # tf.config.experimental.set_memory_growth(tf.config.list_physical_devices("GPU")[0],
+        #                                         True)
+
+        print("\nConfig:", vars(args))
+        print("GPU:", tf.config.list_physical_devices("GPU"))
+        print("")
+
+        print("\n[1/3] Loading model\n")
+
+        if args.type == "cnn":
+            train_items = return_cnn(args.model, batch_size=args.bs, steps=args.steps)
+        elif args.type == "transformer":
+            train_items = return_transformer(args.model, batch_size=args.bs, steps=args.steps)
+        else:
+            raise ValueError("Model type not supported")
+            
+        model = train_items["model"]
+        dataset_x, dataset_y = train_items["sample_data"]
+
+        model.summary()
+
+        print("\n[2/3] Warm-up run\n")
+
+        _ = model.fit(x=dataset_x, y=dataset_y, batch_size=args.bs, epochs=1, verbose=1)
+
+        print("\n[3/3] Benchmark run\n")
+        cbs = [wandb.keras.WandbCallback(save_model=False),]
+        st = time.time()
+        _ = model.fit(x=dataset_x, y=dataset_y, batch_size=args.bs, callbacks=cbs, epochs=args.epochs, verbose=2)
+        et = time.time()
+
+        dataset_size = args.bs*args.steps
+        fps = round(dataset_size*args.epochs/(et-st), 1)
+
+        print("\nTraining Result:")
+        print("Sample/sec:", fps)
+        wandb.log({"fps":fps})
+
+
 print(args)
-
-with wandb.init(project=PROJECT, entity=ENTITY, config=args.__dict__):
-    tf.config.optimizer.set_jit(args.xla)
-    if args.fp16:
-        policy = mixed_precision.Policy("mixed_float16")
-        mixed_precision.set_global_policy(policy)
-        
-    # tf.config.experimental.set_memory_growth(tf.config.list_physical_devices("GPU")[0],
-    #                                         True)
-
-    print("\nConfig:", vars(args))
-    print("GPU:", tf.config.list_physical_devices("GPU"))
-    print("")
-
-    print("\n[1/3] Loading model\n")
-
-    if args.type == "cnn":
-        train_items = return_cnn(args.model, batch_size=args.bs, steps=args.steps)
-    elif args.type == "transformer":
-        train_items = return_transformer(args.model, batch_size=args.bs, steps=args.steps)
-    else:
-        raise ValueError("Model type not supported")
-        
-    model = train_items["model"]
-    dataset_x, dataset_y = train_items["sample_data"]
-
-    model.summary()
-
-    print("\n[2/3] Warm-up run\n")
-
-    _ = model.fit(x=dataset_x, y=dataset_y, batch_size=args.bs, epochs=1, verbose=1)
-
-    print("\n[3/3] Benchmark run\n")
-    cbs = [wandb.keras.WandbCallback(save_model=False),]
-    st = time.time()
-    _ = model.fit(x=dataset_x, y=dataset_y, batch_size=args.bs, callbacks=cbs, epochs=args.epochs, verbose=2)
-    et = time.time()
-
-    dataset_size = args.bs*args.steps
-    fps = round(dataset_size*args.epochs/(et-st), 1)
-
-    print("\nTraining Result:")
-    print("Sample/sec:", fps)
-    wandb.log({"fps":fps})
+train()


### PR DESCRIPTION
This PR adds wandb logging for the training script 🚀 
With this tool, we can compare runs on the dashboard and then get super nice results.
It also automatically logs the apple system metrics like GPU power, CPU power, etc..
I have been also benchmarking the processor recently!

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/18441985/143596989-4696c019-049d-4a0b-9cff-00b0e5a91813.png">

And check the model run [here](https://wandb.ai/tcapelle/tf-metal-experiments?workspace=user-tcapelle)